### PR TITLE
docs: update readme for current api

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 [![NPM Version](https://img.shields.io/npm/v/use-sui-passkey)](https://www.npmjs.com/package/use-sui-passkey)
 # use-sui-passkey
 
-`use-sui-passkey` is a lightweight React hook that simplifies integrating [Sui](https://sui.io) Passkey authentication. It exposes helper functions for registering and signing in with a Passkey and tracks basic state like loading or error information.
+`use-sui-passkey` is a lightweight React hook that simplifies integrating [Sui](https://sui.io) Passkey authentication. It exposes helper functions for creating or recovering a passkey, signing messages or transactions and tracks basic state like loading or error information.
 
 [![welcome](https://raw.githubusercontent.com/denyskozak/use-sui-passkey/refs/heads/main/welcome.png)](https://www.npmjs.com/package/use-sui-passkey)
 
@@ -15,21 +15,31 @@ yarn add use-sui-passkey
 ```
 
 ## Quick start
-#### Look /example for more
+#### Look at `/example` for more
 
 ```tsx
 import { useSuiPasskey } from 'use-sui-passkey';
 
 export default function App() {
-  const { register, signIn, address, error, isLoading, logout } = useSuiPasskey();
+  const {
+    supported,
+    address,
+    create,
+    recoverTwoStep,
+    clear,
+    loading,
+    error,
+  } = useSuiPasskey({ rpName: 'My Dapp' });
+
+  if (!supported) return <div>Passkeys unsupported</div>;
 
   return (
     <div>
-      <button onClick={register} disabled={isLoading}>Create passkey</button>
-      <button onClick={signIn} disabled={isLoading}>Sign in</button>
+      <button onClick={() => create()} disabled={loading}>Create passkey</button>
+      <button onClick={() => recoverTwoStep()} disabled={loading}>Sign in</button>
       {address && <p>Signed in as {address}</p>}
-      {error && <p>{error.message}</p>}
-      {address && <button onClick={logout}>Logout</button>}
+      {error && <p>{String(error)}</p>}
+      {address && <button onClick={clear}>Logout</button>}
     </div>
   );
 }
@@ -37,14 +47,30 @@ export default function App() {
 
 ## API
 
-The `useSuiPasskey` hook returns:
+### `useSuiPasskey(options: UseSuiPasskeyOptions)`
 
-- `register(): Promise<void>` – register a new passkey for the current user.
-- `signIn(): Promise<void>` – authenticate using an existing passkey.
+**Options**
+
+- `rpName: string` – human readable name displayed by the passkey provider.
+- `rpId?: string` – relying party ID. Defaults to the current hostname.
+- `authenticatorAttachment?: 'platform' | 'cross-platform'` – optional hint for UI.
+- `storage?: Storage` – custom persistence. Defaults to `localStorage` in the browser.
+- `storageKey?: string` – key used for persistence. Defaults to an internal value.
+- `autoLoad?: boolean` – rehydrate keypair from storage on mount. Defaults to `true`.
+
+**Returns**
+
+- `supported: boolean` – whether WebAuthn is available in the environment.
+- `initialised: boolean` – whether the underlying provider has been created.
+- `loading: boolean` – indicates whether an operation is in progress.
+- `error: unknown | null` – last error, if any.
 - `address: string | null` – Sui address once authenticated.
-- `error: Error | null` – last error, if any.
-- `isLoading: boolean` – indicates whether an operation is in progress.
-- `logout(): void` – clear local session information.
+- `keypair: PasskeyKeypair | null` – current keypair instance.
+- `create(): Promise<{ keypair: PasskeyKeypair; address: string }>` – register a new passkey and cache its public key.
+- `recoverTwoStep(m1?: Uint8Array | string, m2?: Uint8Array | string): Promise<{ keypair: PasskeyKeypair; address: string }>` – recover an existing passkey using two signed messages.
+- `signPersonalMessage(message: Uint8Array | string): Promise<{ signature: string }>` – sign an arbitrary message.
+- `signTransaction(txBytes: Uint8Array): Promise<{ signature: string }>` – sign a transaction block.
+- `clear(): void` – remove cached public key and reset the hook state.
 
 ## License
 


### PR DESCRIPTION
## Summary
- document the current useSuiPasskey API and options
- refresh quick start example with create/recover helpers and clear

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6899cb5451e4832982fdbd31048f2d6c